### PR TITLE
Fix example JSON response

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,92 +43,92 @@ record a JSON object represents. Possible values include:
 >
 > 4 = LSS Temp/Hum Current Conditions record
 
-{
-
-    "data":
     {
-        "did":"001D0A700002",
-        "ts":1531754005,
-        "conditions": [
+        "data":
         {
-                "lsid":48308,                                  // logical sensor ID **(no unit)**
-                "data_structure_type":1,                       // data structure type **(no unit)**
-                "txid":1,                                      // transmitter ID **(no unit)**
-                "temp": 62.7,                                  // most recent valid temperature **(°F)**
-                "hum":1.1,                                     // most recent valid humidity **(%RH)**
-                "dew_point": -0.3,                             // **(°F)**
-                "wet_bulb":null,                               // **(°F)**
-                "heat_index": 5.5,                             // **(°F)**
-                "wind_chill": 6.0,                             // **(°F)**
-                "thw_index": 5.5,                              // **(°F)**
-                "thsw_index": 5.5,                             // **(°F)**
-                "wind_speed_last":2,                           // most recent valid wind speed **(mph)**
-                "wind_dir_last":null,                          // most recent valid wind direction **(°degree)**
-                "wind_speed_avg_last_1_min":4,                 // average wind speed over last 1 min **(mph)**
-                "wind_dir_scalar_avg_last_1_min":15,           // scalar average wind direction over last 1 min **(°degree)**
-                "wind_speed_avg_last_2_min":42606,             // average wind speed over last 2 min **(mph)**
-                "wind_dir_scalar_avg_last_2_min": 170.7,       // scalar average wind direction over last 2 min **(°degree)**
-                "wind_speed_hi_last_2_min":8,                  // maximum wind speed over last 2 min **(mph)**
-                "wind_dir_at_hi_speed_last_2_min":0.0,         // gust wind direction over last 2 min **(°degree)**
-                "wind_speed_avg_last_10_min":42606,            // average wind speed over last 10 min **(mph)**
-                "wind_dir_scalar_avg_last_10_min": 4822.5,     // scalar average wind direction over last 10 min **(°degree)**
-                "wind_speed_hi_last_10_min":8,                 // maximum wind speed over last 10 min **(mph)**
-                "wind_dir_at_hi_speed_last_10_min":0.0,        // gust wind direction over last 10 min **(°degree)**
-                "rain_size":2,                                 // rain collector type/size **(0: Reserved, 1: 0.01", 2: 0.2 mm, 3:  0.1 mm, 4: 0.001")**
-                "rain_rate_last":0,                            // most recent valid rain rate **(counts/hour)**
-                "rain_rate_hi":null,                           // highest rain rate over last 1 min **(counts/hour)**
-                "rainfall_last_15_min":null,                   // total rain count over last 15 min **(counts)**
-                "rain_rate_hi_last_15_min":0,                  // highest rain rate over last 15 min **(counts/hour)**
-                "rainfall_last_60_min":null,                   // total rain count for last 60 min **(counts)**
-                "rainfall_last_24_hr":null,                    // total rain count for last 24 hours **(counts)**
-                "rain_storm":null,                             // total rain count since last 24 hour long break in rain **(counts)**
-                "rain_storm_start_at":null,                    // UNIX timestamp of current rain storm start **(seconds)**
-                "solar_rad":747,                               // most recent solar radiation **(W/m²)**
-                "uv_index":5.5,                                // most recent UV index **(Index)**
-                "rx_state":2,                                  // configured radio receiver state **(no unit)**
-                "trans_battery_flag":0,                        // transmitter battery status flag **(no unit)**
-                "rainfall_daily":63,                           // total rain count since local midnight **(counts)**
-                "rainfall_monthly":63,                         // total rain count since first of month at local midnight **(counts)**
-                "rainfall_year":63,                            // total rain count since first of user-chosen month at local midnight **(counts)**
-                "rain_storm_last":null,                        // total rain count since last 24 hour long break in rain **(counts)**
-                "rain_storm_last_start_at":null,               // UNIX timestamp of last rain storm start **(sec)**
-                "rain_storm_last_end_at":null                  // UNIX timestamp of last rain storm end **(sec)**
+            "did":"001D0A700002",
+            "ts":1531754005,
+            "conditions":[
+                {
+                    "lsid":48308,                                  // logical sensor ID **(no unit)**
+                    "data_structure_type":1,                       // data structure type **(no unit)**
+                    "txid":1,                                      // transmitter ID **(no unit)**
+                    "temp":62.7,                                   // most recent valid temperature **(°F)**
+                    "hum":1.1,                                     // most recent valid humidity **(%RH)**
+                    "dew_point":-0.3,                              // **(°F)**
+                    "wet_bulb":null,                               // **(°F)**
+                    "heat_index":5.5,                              // **(°F)**
+                    "wind_chill":6.0,                              // **(°F)**
+                    "thw_index":5.5,                               // **(°F)**
+                    "thsw_index":5.5,                              // **(°F)**
+                    "wind_speed_last":2,                           // most recent valid wind speed **(mph)**
+                    "wind_dir_last":null,                          // most recent valid wind direction **(°degree)**
+                    "wind_speed_avg_last_1_min":4,                 // average wind speed over last 1 min **(mph)**
+                    "wind_dir_scalar_avg_last_1_min":15,           // scalar average wind direction over last 1 min **(°degree)**
+                    "wind_speed_avg_last_2_min":42606,             // average wind speed over last 2 min **(mph)**
+                    "wind_dir_scalar_avg_last_2_min":170.7,        // scalar average wind direction over last 2 min **(°degree)**
+                    "wind_speed_hi_last_2_min":8,                  // maximum wind speed over last 2 min **(mph)**
+                    "wind_dir_at_hi_speed_last_2_min":0.0,         // gust wind direction over last 2 min **(°degree)**
+                    "wind_speed_avg_last_10_min":42606,            // average wind speed over last 10 min **(mph)**
+                    "wind_dir_scalar_avg_last_10_min":4822.5,      // scalar average wind direction over last 10 min **(°degree)**
+                    "wind_speed_hi_last_10_min":8,                 // maximum wind speed over last 10 min **(mph)**
+                    "wind_dir_at_hi_speed_last_10_min":0.0,        // gust wind direction over last 10 min **(°degree)**
+                    "rain_size":2,                                 // rain collector type/size **(0: Reserved, 1: 0.01", 2: 0.2 mm, 3:  0.1 mm, 4: 0.001")**
+                    "rain_rate_last":0,                            // most recent valid rain rate **(counts/hour)**
+                    "rain_rate_hi":null,                           // highest rain rate over last 1 min **(counts/hour)**
+                    "rainfall_last_15_min":null,                   // total rain count over last 15 min **(counts)**
+                    "rain_rate_hi_last_15_min":0,                  // highest rain rate over last 15 min **(counts/hour)**
+                    "rainfall_last_60_min":null,                   // total rain count for last 60 min **(counts)**
+                    "rainfall_last_24_hr":null,                    // total rain count for last 24 hours **(counts)**
+                    "rain_storm":null,                             // total rain count since last 24 hour long break in rain **(counts)**
+                    "rain_storm_start_at":null,                    // UNIX timestamp of current rain storm start **(seconds)**
+                    "solar_rad":747,                               // most recent solar radiation **(W/m²)**
+                    "uv_index":5.5,                                // most recent UV index **(Index)**
+                    "rx_state":2,                                  // configured radio receiver state **(no unit)**
+                    "trans_battery_flag":0,                        // transmitter battery status flag **(no unit)**
+                    "rainfall_daily":63,                           // total rain count since local midnight **(counts)**
+                    "rainfall_monthly":63,                         // total rain count since first of month at local midnight **(counts)**
+                    "rainfall_year":63,                            // total rain count since first of user-chosen month at local midnight **(counts)**
+                    "rain_storm_last":null,                        // total rain count since last 24 hour long break in rain **(counts)**
+                    "rain_storm_last_start_at":null,               // UNIX timestamp of last rain storm start **(sec)**
+                    "rain_storm_last_end_at":null                  // UNIX timestamp of last rain storm end **(sec)**
+                },
+                {
+                    "lsid":3187671188,
+                    "data_structure_type":2,
+                    "txid":3,
+                    "temp_1":null,                                 // most recent valid soil temp slot 1 **(°F)**
+                    "temp_2":null,                                 // most recent valid soil temp slot 2 **(°F)**
+                    "temp_3":null,                                 // most recent valid soil temp slot 3 **(°F)**
+                    "temp_4":null,                                 // most recent valid soil temp slot 4 **(°F)**
+                    "moist_soil_1":null,                           // most recent valid soil moisture slot 1 **(|cb|)**
+                    "moist_soil_2":null,                           // most recent valid soil moisture slot 2 **(|cb|)**
+                    "moist_soil_3":null,                           // most recent valid soil moisture slot 3 **(|cb|)**
+                    "moist_soil_4":null,                           // most recent valid soil moisture slot 4 **(|cb|)**
+                    "wet_leaf_1":null,                             // most recent valid leaf wetness slot 1 **(no unit)**
+                    "wet_leaf_2":null,                             // most recent valid leaf wetness slot 2 **(no unit)**
+                    "rx_state":null,                               // configured radio receiver state **(no unit)**
+                    "trans_battery_flag":null                      // transmitter battery status flag **(no unit)**
+                },
+                {
+                    "lsid":48307,
+                    "data_structure_type":4,
+                    "temp_in":78.0,                                // most recent valid inside temp **(°F)**
+                    "hum_in":41.1,                                 // most recent valid inside humidity **(%RH)**
+                    "dew_point_in":7.8,                            // **(°F)**
+                    "heat_index_in":8.4                            // **(°F)**
+                },
+                {
+                    "lsid":48306,
+                    "data_structure_type":3,
+                    "bar_sea_level":30.008,                        // most recent bar sensor reading with elevation adjustment **(inches)**
+                    "bar_trend":null,                              // current 3 hour bar trend **(inches)**
+                    "bar_absolute":30.008                          // raw bar sensor reading **(inches)**
+                }
+            ]
         },
-        {
-                "lsid":3187671188,
-                "data_structure_type":2,
-                "txid":3,
-                "temp_1":null,                                 // most recent valid soil temp slot 1 **(°F)**
-                "temp_2":null,                                 // most recent valid soil temp slot 2 **(°F)**
-                "temp_3":null,                                 // most recent valid soil temp slot 3 **(°F)**
-                "temp_4":null,                                 // most recent valid soil temp slot 4 **(°F)**
-                "moist_soil_1":null,                           // most recent valid soil moisture slot 1 **(|cb|)**
-                "moist_soil_2":null,                           // most recent valid soil moisture slot 2 **(|cb|)**
-                "moist_soil_3":null,                           // most recent valid soil moisture slot 3 **(|cb|)**
-                "moist_soil_4":null,                           // most recent valid soil moisture slot 4 **(|cb|)**
-                "wet_leaf_1":null,                             // most recent valid leaf wetness slot 1 **(no unit)**
-                "wet_leaf_2":null,                             // most recent valid leaf wetness slot 2 **(no unit)**
-                "rx_state":null,                               // configured radio receiver state **(no unit)**
-                "trans_battery_flag":null                      // transmitter battery status flag **(no unit)**
-        },
-        {
-                "lsid":48307,
-                "data_structure_type":4,
-                "temp_in":78.0,                                // most recent valid inside temp **(°F)**
-                "hum_in":41.1,                                 // most recent valid inside humidity **(%RH)**
-                "dew_point_in":7.8,                            // **(°F)**
-                "heat_index_in":8.4                            // **(°F)**
-        },
-        {
-                "lsid":48306,
-                "data_structure_type":3,
-                "bar_sea_level":30.008,                       // most recent bar sensor reading with elevation adjustment **(inches)**
-                "bar_trend": null,                            // current 3 hour bar trend **(inches)**
-                "bar_absolute":30.008                         // raw bar sensor reading **(inches)**
-        }]
-    },
-    "error":null
-}
+        "error":null
+    }
 
 ##### Receiver State
 The `rx_state` field describes the radio reception state for the transmitter.
@@ -207,12 +207,11 @@ record a JSON object represents. Possible values include:
 
 ###### First Broadcast Packet (with 3 ISS Sensors):
 
-{
-
+    {
         "did":"001D0A700002",
         "ts":1532031640,
         "conditions": [
-        {
+            {
                 "lsid":3187671188,                           // logical sensor ID **(no unit)**
                 "data_structure_type":1,                     // data structure type **(no unit)**
                 "txid":1,                                    // transmitter ID **(no unit)**
@@ -230,8 +229,8 @@ record a JSON object represents. Possible values include:
                 "rainfall_year":63,                          // total rain count since first of the user chosen month at local midnight **(counts)** 
                 "wind_speed_hi_last_10_min":null,            // maximum wind speed over last 10 min **(mph)**
                 "wind_dir_at_hi_speed_last_10_min":null      // gust wind direction over last 10 min **(°degree)**
-        },
-        {
+            },
+            {
                 "lsid":3422552209,
                 "data_structure_type":1,
                 "txid":2,
@@ -249,8 +248,8 @@ record a JSON object represents. Possible values include:
                 "rainfall_year":10,
                 "wind_speed_hi_last_10_min":null,
                 "wind_dir_at_hi_speed_last_10_min":null
-        },
-        {
+            },
+            {
                 "lsid":3724542100,
                 "data_structure_type":1,
                 "txid":3,
@@ -268,17 +267,17 @@ record a JSON object represents. Possible values include:
                 "rainfall_year":0,
                 "wind_speed_hi_last_10_min":null,
                 "wind_dir_at_hi_speed_last_10_min":null
-        }]
-}
+            }
+        ]
+    }
 
 ###### Second Broadcast Packet (with next 3 ISS Sensors):
 
-{
-
+    {
         "did":"001D0A700002",
         "ts":1532031640,
-        "conditions": [
-        {
+        "conditions":[
+            {
                 "lsid":4261413012,
                 "data_structure_type":1,
                 "txid":4,
@@ -296,8 +295,8 @@ record a JSON object represents. Possible values include:
                 "rainfall_year":0,
                 "wind_speed_hi_last_10_min":null,
                 "wind_dir_at_hi_speed_last_10_min":null
-        },
-        {
+            },
+            {
                 "lsid":2902458513,
                 "data_structure_type":1,
                 "txid":5,
@@ -315,8 +314,8 @@ record a JSON object represents. Possible values include:
                 "rainfall_year":0,
                 "wind_speed_hi_last_10_min":null,
                 "wind_dir_at_hi_speed_last_10_min":null
-        },
-        {
+            },
+            {
                 "lsid":3187671185,
                 "data_structure_type":1,
                 "txid":6,
@@ -334,17 +333,17 @@ record a JSON object represents. Possible values include:
                 "rainfall_year":0,
                 "wind_speed_hi_last_10_min":null,
                 "wind_dir_at_hi_speed_last_10_min":null
-        }]
-}
+            }
+        ]
+    }
 
 ###### Third Broadcast Packet (with remaining 2 ISS Sensors):
 
-{
-
+    {
         "did":"001D0A700002",
         "ts":1532031640,
-        "conditions": [
-        {
+        "conditions":[
+            {
                 "lsid":4261413012,
                 "data_structure_type":1,
                 "txid":7,
@@ -362,8 +361,8 @@ record a JSON object represents. Possible values include:
                 "rainfall_year":0,
                 "wind_speed_hi_last_10_min":null,
                 "wind_dir_at_hi_speed_last_10_min":null
-        },
-        {
+            },
+            {
                 "lsid":2902458513,
                 "data_structure_type":1,
                 "txid":8,
@@ -381,9 +380,9 @@ record a JSON object represents. Possible values include:
                 "rainfall_year":0,
                 "wind_speed_hi_last_10_min":null,
                 "wind_dir_at_hi_speed_last_10_min":null
-        }]
-
-}
+            }
+        ]
+    }
 
 # Appendix
 
@@ -395,14 +394,13 @@ record a JSON object represents. Possible values include:
 
 ###### Response string
 
-{
-
-    "data":null,
-    "error":{
-                "code":404,
-                "message":"HTTP Page Not Found"
+    {
+        "data":null,
+        "error":{
+            "code":404,
+            "message":"HTTP Page Not Found"
+        }
     }
-}
 
 ###### HTTP Request
 
@@ -410,14 +408,13 @@ record a JSON object represents. Possible values include:
 
 ###### Response string
 
-{
-
-    "data":null,
-    "error":{
-                "code":400,
-                "message":"HTTP Bad Request"
+    {
+        "data":null,
+        "error":{
+            "code":400,
+            "message":"HTTP Bad Request"
+        }
     }
-}
 
 ###### HTTP Request
 
@@ -425,14 +422,13 @@ record a JSON object represents. Possible values include:
 
 ###### Response string
 
-{
-
-    "data":null,
-    "error":{
-                "code":414,
-                "message": "HTTP URI Too Long"
+    {
+        "data":null,
+        "error":{
+            "code":414,
+            "message":"HTTP URI Too Long"
+        }
     }
-}
 
 ###### HTTP Request - (When there are no ISS Transmitter configured, but Real-Time broadcast request is made)
 
@@ -444,14 +440,13 @@ record a JSON object represents. Possible values include:
 
 ###### Response string
 
-{
-
-    "data":null,
-    "error":{
-                "code":409,
-                "message": "No ISS Transmitters. Real Time broadcast not enabled"
+    {
+        "data":null,
+        "error":{
+            "code":409,
+            "message":"No ISS Transmitters. Real Time broadcast not enabled"
+        }
     }
-}
 
 #### Current Conditions HTTP Request -- Helper Module
 

--- a/API.md
+++ b/API.md
@@ -64,8 +64,8 @@ record a JSON object represents. Possible values include:
                 "thsw_index": 5.5,                             // **(°F)**
                 "wind_speed_last":2,                           // most recent valid wind speed **(mph)**
                 "wind_dir_last":null,                          // most recent valid wind direction **(°degree)**
-                "wind_speed_avg_last_1_min":4                  // average wind speed over last 1 min **(mph)**
-                "wind_dir_scalar_avg_last_1_min":15            // scalar average wind direction over last 1 min **(°degree)**
+                "wind_speed_avg_last_1_min":4,                 // average wind speed over last 1 min **(mph)**
+                "wind_dir_scalar_avg_last_1_min":15,           // scalar average wind direction over last 1 min **(°degree)**
                 "wind_speed_avg_last_2_min":42606,             // average wind speed over last 2 min **(mph)**
                 "wind_dir_scalar_avg_last_2_min": 170.7,       // scalar average wind direction over last 2 min **(°degree)**
                 "wind_speed_hi_last_2_min":8,                  // maximum wind speed over last 2 min **(mph)**
@@ -399,7 +399,7 @@ record a JSON object represents. Possible values include:
 
     "data":null,
     "error":{
-                "code":404
+                "code":404,
                 "message":"HTTP Page Not Found"
     }
 }
@@ -414,7 +414,7 @@ record a JSON object represents. Possible values include:
 
     "data":null,
     "error":{
-                "code":400
+                "code":400,
                 "message":"HTTP Bad Request"
     }
 }
@@ -429,7 +429,7 @@ record a JSON object represents. Possible values include:
 
     "data":null,
     "error":{
-                "code":414
+                "code":414,
                 "message": "HTTP URI Too Long"
     }
 }
@@ -448,7 +448,7 @@ record a JSON object represents. Possible values include:
 
     "data":null,
     "error":{
-                "code":409
+                "code":409,
                 "message": "No ISS Transmitters. Real Time broadcast not enabled"
     }
 }


### PR DESCRIPTION
I use the example JSON response for testing. After stripping the comments (see snippet below), I realized it's not valid JSON because of missing separators. Also changed to formatting a little bit to be consistent.

```py
RESPONSE = re.sub(r"\s+//.*$", "", RESPONSE_WITH_COMMENTS, flags=re.MULTILINE)
```

